### PR TITLE
Removing icon defintion from block.json

### DIFF
--- a/src/block.json
+++ b/src/block.json
@@ -5,7 +5,6 @@
 	"version": "0.1.0",
 	"title": "Askell Registration",
 	"category": "widgets",
-	"icon": "id",
 	"description": "Sign up for recurring subscriptions directly from WordPress using Askell",
 	"supports": {
 		"html": false


### PR DESCRIPTION
This should be taken care of by index.js instead.