### PR TITLE
Fixing admin form

### DIFF
--- a/class-askellregistration.php
+++ b/class-askellregistration.php
@@ -1141,6 +1141,20 @@ class AskellRegistration {
 			);
 		}
 
+		if ( array_key_exists( 'register_url', $request_body ) ) {
+			update_option(
+				'askell_register_url',
+				$request_body['register_url']
+			);
+		}
+
+		if ( array_key_exists( 'tos_url', $request_body ) ) {
+			update_option(
+				'askell_tos_url',
+				$request_body['tos_url']
+			);
+		}
+
 		return true;
 	}
 

--- a/src/admin.js
+++ b/src/admin.js
@@ -25,6 +25,8 @@ class AskellUI {
 			subscription_webhook_secret: formData.get(
 				'subscription_webhook_secret'
 			).trim(),
+			register_url: formData.get('register_url').trim(),
+			tos_url: formData.get('askell_tos_url').trim(),
 			paywall_heading: formData.get('paywall_heading').trim(),
 			paywall_text_body: formData.get( 'paywall_text_body' ).trim(),
 			enable_css: Boolean(formData.get('enable_css')),

--- a/views/admin.php
+++ b/views/admin.php
@@ -195,8 +195,8 @@ $askell_registration = new AskellRegistration();
 							<input
 								class="regular-text"
 								type="text"
-								name="api_secret"
-								value="<?php echo esc_attr( get_option( 'askell_terms_url', '' ) ); ?>"
+								name="tos_url"
+								value="<?php echo esc_attr( get_option( 'askell_tos_url', '' ) ); ?>"
 							/>
 							<p class="description">This is the URL to where you keep your terms and conditions to be accepted during the registration process.</p>
 						</td>


### PR DESCRIPTION
The TOS and registration URL fields didn't work, but they do now.