### PR TITLE
Fixing the visibility of check_user_is_logged_in

### DIFF
--- a/classes/class-wprest.php
+++ b/classes/class-wprest.php
@@ -936,7 +936,7 @@ class WpRest {
 	 *
 	 * @return bool True if the user is logged in, false if not.
 	 */
-	private function check_user_is_logged_in() {
+	public function check_user_is_logged_in() {
 		$current_user = wp_get_current_user();
 
 		if ( 0 === $current_user->ID ) {


### PR DESCRIPTION
This one is used in a callable so it needs to be public.