### PR TITLE
Adding the classes directory to the files listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	"files": [
 		"readme.txt",
 		"askell-registration.php",
-		"class-askellregistration.php",
+		"classes",
 		"views",
 		"build",
 		"assets",


### PR DESCRIPTION
This fixes issues with the `plugin-zip` task as the PHP classes were not being included in the package.